### PR TITLE
Bug fix for cases when touch does not work because touches is not defined on jQuery event

### DIFF
--- a/src/angular-sortable-view.js
+++ b/src/angular-sortable-view.js
@@ -544,9 +544,12 @@
 	].join(''));
 
 	function touchFix(e){
-		if(!('clientX' in e) && !('clientY' in e)){
-			e.clientX = e.touches[0].clientX;
-			e.clientY = e.touches[0].clientY;
+		if(!('clientX' in e) && !('clientY' in e)) {
+			var touches = e.touches || e.originalEvent.touches;
+			if(touches && touches.length) {
+				e.clientX = touches[0].clientX;
+				e.clientY = touches[0].clientY;
+			}
 			e.preventDefault();
 		}
 	}


### PR DESCRIPTION
For cases when event is actually jQuery event touches array would be defined on event.originalEvent instead of just event. function touchFix() is adjusted to be aware of such cases.
