### PR TITLE
updated svHandle to use $scope.$ctrl rather than $ctrl

### DIFF
--- a/src/angular-sortable-view.js
+++ b/src/angular-sortable-view.js
@@ -486,8 +486,8 @@
 		return {
 			require: '?^svElement',
 			link: function($scope, $element, $attrs, $ctrl){
-				if($ctrl)
-					$ctrl.handle = $element.add($ctrl.handle); // support multiple handles
+				if($scope.$ctrl)
+					$scope.$ctrl.handle = $element.add($scope.$ctrl.handle); // support multiple handles
 			}
 		};
 	});


### PR DESCRIPTION
$ctrl is undefined within svHandle, but $scope.$ctrl is defined and is watched by svElement. Handles didn't work before (for me) but they do now.