### PR TITLE
fix unintended side effects from PR-#9.

### DIFF
--- a/src/angular-sortable-view.js
+++ b/src/angular-sortable-view.js
@@ -458,10 +458,10 @@
 						html.off('mousemove touchmove', onMousemove);
 						html.off('mouseup touchend', mouseup);
 						html.removeClass('sv-sorting-in-progress');
-						if(moveExecuted)
+						if(moveExecuted){
 							$controllers[0].$drop($scope.$index, opts);
-						else
-							$element.removeClass('sv-visibility-hidden');
+						}
+						$element.removeClass('sv-visibility-hidden');
 					});
 
 					// onMousemove(e);


### PR DESCRIPTION
remove class “sv-visibility-hidden” regardless of whether a move is executed or not, as this class gets added on click and not on move.

this results in the element disappearing (being hidden by sv-visibility-hidden) if its not moved (it source and destination are the same upon drop)

you can see this on the demo page with helpers.