### PR TITLE
when using helpers, only add “sv-visibility-hidden” on move

### DIFF
--- a/src/angular-sortable-view.js
+++ b/src/angular-sortable-view.js
@@ -417,7 +417,6 @@
 							'left': clientRect.left + document.body.scrollLeft + 'px',
 							'top': clientRect.top + document.body.scrollTop + 'px'
 						});
-						target.addClass('sv-visibility-hidden');
 					}
 					else{
 						clone = target.clone();
@@ -470,6 +469,9 @@
 						if(!moveExecuted){
 							$element.parent().prepend(clone);
 							moveExecuted = true;
+						}
+						if(helper){
+							target.addClass('sv-visibility-hidden');
 						}
 						$controllers[1].$moveUpdate(opts, {
 							x: e.clientX,


### PR DESCRIPTION
Currently, the sv-visibility-hidden is added on click. For elements that have helpers, this causes them to be hidden on click (but not move), yet the helper doesn't appear until a mousemove event.

this patch makes sure that the sv-visibility-hidden class gets applied at the same time when the helper element is created, and not before (on click)