### PR TITLE
fix #12 and #38

### DIFF
--- a/src/angular-sortable-view.js
+++ b/src/angular-sortable-view.js
@@ -129,7 +129,7 @@
 						$helper = svElement;
 
 						onStart($scope, {
-							$helper: $helper,
+							$helper: {element: $helper},
 							$part: originatingPart.model(originatingPart.scope),
 							$index: originatingIndex,
 							$item: originatingPart.model(originatingPart.scope)[originatingIndex]


### PR DESCRIPTION
pass the DOM element in an object instead of plainly.

Angular doesn't like it if you try to pass a DOM element directly to a controller. By wrapping it in an object, the error (isecdom) is fixed.