### PR TITLE
Explicit parent

### DIFF
--- a/src/angular-sortable-view.js
+++ b/src/angular-sortable-view.js
@@ -39,7 +39,8 @@
 				var $target; // last best candidate
 				var isGrid = false;
 				var onSort = $parse($attrs.svOnSort);
-
+				var parentIsRelative = $attrs.hasRelativeParent ? $($attrs.hasRelativeParent) : false;
+				
 				// ----- hack due to https://github.com/angular/angular.js/issues/8044
 				$attrs.svOnStart = $attrs.$$element[0].attributes['sv-on-start'];
 				$attrs.svOnStart = $attrs.svOnStart && $attrs.svOnStart.value; 
@@ -71,7 +72,7 @@
 						}).map(function(item){
 							return {
 								part: item.getPart().id,
-								y: item.element[0].getBoundingClientRect().top
+								y: !parentIsRelative ? item.element[0].getBoundingClientRect().top : (item.element[0].getBoundingClientRect().top - parentIsRelative.offset().top )
 							};
 						});
 						var dict = Object.create(null);
@@ -93,7 +94,18 @@
 						});
 					});
 				}
+				
+				this.relativeParentOffset = function() {
 
+                    		if (!parentIsRelative)
+		                        return {
+		                            top: 0,
+		                            left: 0
+		                        };
+
+		                    return $(parentIsRelative).offset();
+		                };
+				
 				this.$moveUpdate = function(opts, mouse, svElement, svOriginal, svPlaceholder, originatingPart, originatingIndex){
 					var svRect = svElement[0].getBoundingClientRect();
 					if(opts.tolerance === 'element')
@@ -138,8 +150,8 @@
 
 					// ----- move the element
 					$helper[0].reposition({
-						x: mouse.x + document.body.scrollLeft - mouse.offset.x*svRect.width,
-						y: mouse.y + document.body.scrollTop - mouse.offset.y*svRect.height
+						x: (mouse.x + document.body.scrollLeft - mouse.offset.x*svRect.width) - that.relativeParentOffset().left,
+                        			y: (mouse.y + document.body.scrollTop - mouse.offset.y*svRect.height) - that.relativeParentOffset().top
 					});
 
 					// ----- manage candidates


### PR DESCRIPTION
added attribute to explicitly state a relative parent to base the offset off of. This fixes an issue where when dragging an element if it has a relative parent the element does not follow the cursor correctly and has an incorrect offset.