### PR TITLE
opts.containment sometimes comes as an object not an array

### DIFF
--- a/src/angular-sortable-view.js
+++ b/src/angular-sortable-view.js
@@ -401,7 +401,12 @@
 						containment: 'html'
 					}, opts);
 					if(opts.containment){
-						var containmentRect = closestElement.call($element, opts.containment)[0].getBoundingClientRect();
+						if(opts.containment instanceof Array){
+							var containmentRect = closestElement.call($element, opts.containment)[0].getBoundingClientRect();
+						}
+						else{
+							var containmentRect = closestElement.call($element, opts.containment).getBoundingClientRect();
+						}
 					}
 
 					var target = $element;


### PR DESCRIPTION
In some instances, opts.containment is not an array. Since it is handled as an array in current codes need to modify codes to handle it such that it works well in both scenarios. 