### PR TITLE
Exposed the scope of the target view.

### DIFF
--- a/src/angular-sortable-view.js
+++ b/src/angular-sortable-view.js
@@ -272,7 +272,8 @@
 									$partFrom: originatingPart.model(originatingPart.scope),
 									$item: spliced[0],
 									$indexTo: targetIndex,
-									$indexFrom: index
+									$indexFrom: index,
+									$partToScope: $target.view.scope
 								});
 
 						}


### PR DESCRIPTION
When you provide a method to handle onSort  call you implicitly have access to the FROM container's $scope.
This then allows you to access the $scope of the TARGET container for the DnD operation.