### PR TITLE
Remove svElement event listeners on $destroy

### DIFF
--- a/src/angular-sortable-view.js
+++ b/src/angular-sortable-view.js
@@ -410,6 +410,7 @@
 				$controllers[1].addToSortableElements(sortableElement);
 				$scope.$on('$destroy', function(){
 					$controllers[1].removeFromSortableElements(sortableElement);
+					html.off('mousemove touchmove', onMousemove);
 				});
 
 				var handle = $element;
@@ -520,20 +521,20 @@
 						}
 						$element.removeClass('sv-visibility-hidden');
 					});
+				}
 
-					// onMousemove(e);
-					function onMousemove(e){
-						touchFix(e);
-						if(!moveExecuted){
-							$element.parent().prepend(clone);
-							moveExecuted = true;
-						}
-						$controllers[1].$moveUpdate(opts, {
-							x: e.clientX,
-							y: e.clientY,
-							offset: pointerOffset
-						}, clone, $element, placeholder, $controllers[0].getPart(), $scope.$index);
+				// onMousemove(e);
+				function onMousemove(e){
+					touchFix(e);
+					if(!moveExecuted){
+						$element.parent().prepend(clone);
+						moveExecuted = true;
 					}
+					$controllers[1].$moveUpdate(opts, {
+						x: e.clientX,
+						y: e.clientY,
+						offset: pointerOffset
+					}, clone, $element, placeholder, $controllers[0].getPart(), $scope.$index);
 				}
 			}
 		};


### PR DESCRIPTION
This fixes a `Cannot read property 'forEach' of undefined` throw that happens if one of the sortable elements has a child with a `mouseup` event handler that calls `Event.stopPropagation()`. In that case, the `svElement` `mousedown`/`touchstart` event handler fires, registering the `mousemove`/`touchmove` event handler on the `documentElement`, but there's no `mouseup` because it was stopped from propagating. This event handler keeps being registered even if the component doesn't exist anymore.

The fix involves de-registering the `mousemove`/`touchmove` event handler on the `svElement`'s `$destroy` event.